### PR TITLE
feat: Enhance API documentation with Swagger annotations across multiple controllers

### DIFF
--- a/src/main/java/com/escaes/jobsy/config/SecurityConfig.java
+++ b/src/main/java/com/escaes/jobsy/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
                         // .requestMatchers("/v1/users/create").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/webjars/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/v1/public/**").permitAll()
                         .requestMatchers("/v1/jobs/**").hasAnyRole("USER", "ADMIN")

--- a/src/main/java/com/escaes/jobsy/config/SwaggerConfig.java
+++ b/src/main/java/com/escaes/jobsy/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.escaes.jobsy.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +20,18 @@ public class SwaggerConfig {
                         .description("Plataforma web de micro-trabajos para los estudiantes del PCJIC. "
                                 + "Este sistema permite la publicación, gestión y asignación de tareas con registro seguro "
                                 + "y validación administrativa, optimizando el uso del tiempo libre, "
-                                + "fortaleciendo la economía estudiantil y fomentando la ayuda mutua dentro de la comunidad universitaria."));
+                                + "fortaleciendo la economía estudiantil y fomentando la ayuda mutua dentro de la comunidad universitaria.\n\n"
+                                + "## Autenticación\n"
+                                + "La API usa autenticación **JWT Bearer**. Para los endpoints protegidos, primero obtén un token "
+                                + "en `POST /auth/login` y luego haz clic en **Authorize** e ingresa `<tu-token>`.")
+                        .contact(new Contact()
+                                .name("Equipo Jobsi")
+                                .email("esteban.estra2004@gmail.com")))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Token JWT obtenido desde POST /auth/login")));
     }
 }

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/AuthController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/AuthController.java
@@ -4,6 +4,11 @@ import com.escaes.jobsy.application.dto.auth.JwtResponse;
 import com.escaes.jobsy.application.dto.auth.LoginRequest;
 import com.escaes.jobsy.config.jwt.JwtProvider;
 //import com.escaes.jobsy.domain.repository.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +21,20 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
-@Tag(name="Autenticación", description="Operaciones de autenticación y autorización")
+@Tag(name = "Autenticación", description = "Operaciones de autenticación y autorización")
 public class AuthController {
 
     //private final AuthService authService;
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtUtil;
 
+    @Operation(summary = "Iniciar sesión", description = "Autentica al usuario y devuelve un token JWT para usar en los endpoints protegidos.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Login exitoso — devuelve el token JWT",
+                content = @Content(schema = @Schema(implementation = JwtResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Credenciales incorrectas", content = @Content),
+        @ApiResponse(responseCode = "400", description = "Solicitud inválida (campos faltantes)", content = @Content)
+    })
     @PostMapping("/login")
     public ResponseEntity<JwtResponse> login(@RequestBody LoginRequest loginRequest) {
         Authentication authentication = authenticationManager.authenticate(

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/CategoriaController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/CategoriaController.java
@@ -6,6 +6,13 @@ import com.escaes.jobsy.application.usecase.categoria.GestionCategoriasUseCase;
 import com.escaes.jobsy.application.usecase.categoria.ListarCategoriasUseCase;
 import com.escaes.jobsy.domain.model.Categoria;
 import com.escaes.jobsy.infraestructure.mapper.CategoriaMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +22,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@Tag(name = "Categorias", description = "Operaciones de gestion de categorias (ADMIN)")
+@Tag(name = "Categorias", description = "Operaciones de gestión de categorías — requiere rol ADMIN")
+@SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class CategoriaController {
@@ -24,17 +32,43 @@ public class CategoriaController {
 
     private final ListarCategoriasUseCase  listarCategoriasUseCase;
 
+    @Operation(summary = "Listar todas las categorías", description = "Devuelve todas las categorías registradas en el sistema.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de categorías",
+                content = @Content(schema = @Schema(implementation = CatergoriaResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/category-all")
     public ResponseEntity<List<CatergoriaResponse>> listarCategorias(){
         return ResponseEntity.ok(listarCategoriasUseCase.listarCategorias().stream()
                 .map(CategoriaMapper::entityToResponse).toList());
     }
+
+    @Operation(summary = "Buscar categoría por nombre", description = "Retorna la categoría cuyo nombre coincida exactamente con el proporcionado.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Categoría encontrada",
+                content = @Content(schema = @Schema(implementation = CatergoriaResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Categoría no encontrada", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/category/{name}")
-    public ResponseEntity<CatergoriaResponse> getCategoria(@PathVariable String name){
+    public ResponseEntity<CatergoriaResponse> getCategoria(
+            @Parameter(description = "Nombre exacto de la categoría", example = "Tecnología")
+            @PathVariable String name){
         Categoria categoria = gestionCategoriasUseCase.buscarCategoriaPorNombre(name);
         return ResponseEntity.ok(new CatergoriaResponse(categoria.nombre()));
     }
 
+    @Operation(summary = "Crear nueva categoría", description = "Crea una categoría nueva. El nombre debe ser único.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Categoría creada exitosamente",
+                content = @Content(schema = @Schema(implementation = CatergoriaResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos o categoría ya existente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @PostMapping("/admin/category/create")
     public ResponseEntity<CatergoriaResponse> createCategoria(@RequestBody CategoriaRequest request){
         gestionCategoriasUseCase.crearCategoria(request.nombre());

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/EstadoController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/EstadoController.java
@@ -6,6 +6,13 @@ import com.escaes.jobsy.application.usecase.estado.GestionEstadosUseCase;
 import com.escaes.jobsy.application.usecase.estado.ListarEstadosUseCase;
 import com.escaes.jobsy.domain.model.Estado;
 import com.escaes.jobsy.infraestructure.mapper.EstadoMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,7 +23,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@Tag(name="Estados", description = "Gestion de estados de trabajos(ADMIN)")
+@Tag(name = "Estados", description = "Gestión de estados de trabajos — requiere rol ADMIN")
+@SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class EstadoController {
@@ -26,6 +34,14 @@ public class EstadoController {
     private final ListarEstadosUseCase listarEstadosUseCase;
 
 
+    @Operation(summary = "Crear nuevo estado", description = "Registra un nuevo estado de trabajo (ej. DISPONIBLE, EN_PROCESO, FINALIZADO).")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Estado creado exitosamente",
+                content = @Content(schema = @Schema(implementation = EstadoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos o estado ya existente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @PostMapping("/admin/create/state")
     public ResponseEntity<EstadoResponse> createEstado(@RequestBody EstadoRequest request){
         gestionEstadosUseCase.crearEstado(request);
@@ -33,12 +49,29 @@ public class EstadoController {
                 .body(EstadoMapper.requestToResponse(request));
     }
 
+    @Operation(summary = "Buscar estado por nombre", description = "Retorna el estado cuyo nombre coincida exactamente.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Estado encontrado",
+                content = @Content(schema = @Schema(implementation = EstadoResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Estado no encontrado", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/state/{name}")
-    public ResponseEntity<EstadoResponse> getEstado(@PathVariable String name){
+    public ResponseEntity<EstadoResponse> getEstado(
+            @Parameter(description = "Nombre exacto del estado", example = "DISPONIBLE")
+            @PathVariable String name){
         Estado estado = gestionEstadosUseCase.obtenerEstadoPorNombre(name);
         return ResponseEntity.ok(EstadoMapper.entityToResponse(estado));
     }
 
+    @Operation(summary = "Listar todos los estados", description = "Devuelve todos los estados de trabajo disponibles en el sistema.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de estados",
+                content = @Content(schema = @Schema(implementation = EstadoResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/state-all")
     public ResponseEntity<List<EstadoResponse>> getAllEstado(){
         return ResponseEntity.ok(listarEstadosUseCase.listarEstados().stream().map(

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/GeneroController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/GeneroController.java
@@ -5,6 +5,12 @@ import com.escaes.jobsy.application.dto.genero.GeneroResponse;
 import com.escaes.jobsy.application.usecase.genero.GestionGenerosUseCase;
 //import com.escaes.jobsy.application.usecase.genero.ListarGenerosUseCase;
 import com.escaes.jobsy.infraestructure.mapper.GeneroMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +21,8 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1")
-@Tag(name = "Generos", description = "Operaciones relacionadas con géneros")
+@Tag(name = "Generos", description = "Gestión de géneros de usuario — requiere rol ADMIN")
+@SecurityRequirement(name = "bearerAuth")
 @RequiredArgsConstructor
 public class GeneroController {
 
@@ -23,6 +30,14 @@ public class GeneroController {
 
     //private final ListarGenerosUseCase listarGenerosUseCase;
 
+    @Operation(summary = "Crear nuevo género", description = "Registra un nuevo género disponible para el perfil de usuario (ej. MASCULINO, FEMENINO, NO_BINARIO).")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Género creado exitosamente",
+                content = @Content(schema = @Schema(implementation = GeneroResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos o género ya existente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @PostMapping("/admin/gender/create")
     public ResponseEntity<GeneroResponse> crearGenero(@RequestBody GeneroRequest request) {
         gestionGenerosUseCase.crearGenero(request);

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/InstitucionController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/InstitucionController.java
@@ -10,6 +10,13 @@ import com.escaes.jobsy.application.usecase.institucion.GestionInstitucionesUseC
 import com.escaes.jobsy.application.usecase.institucion.ListarInstitucionesUseCase;
 import com.escaes.jobsy.domain.model.Institucion;
 import com.escaes.jobsy.infraestructure.mapper.InstitucionMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,7 +27,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/v1")
-@Tag(name = "Instituciones",description = "Gestion de instituciones con sus respectivas ubicaciones")
+@Tag(name = "Instituciones", description = "Gestión de instituciones educativas y consultas de ubicación geográfica (departamentos y municipios)")
 @RequiredArgsConstructor
 public class InstitucionController {
 
@@ -30,7 +37,15 @@ public class InstitucionController {
 
     private final UbicacionService ubicacionService;
 
-    // ------------------- Crear institución -------------------
+    @Operation(summary = "Crear institución", description = "Registra una nueva institución educativa en el sistema. Requiere rol ADMIN.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Institución creada exitosamente",
+                content = @Content(schema = @Schema(implementation = InstitucionResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @PostMapping("/admin/create-institution")
     public ResponseEntity<InstitucionResponse> crearInstitucion(@RequestBody InstitucionRequest request) {
         gestionInstitucionesUseCase.crearInstitucion(request);
@@ -38,29 +53,53 @@ public class InstitucionController {
                 .body(InstitucionMapper.requestToResponse(request));
     }
 
-    //Obtener departamentos y municipios relacionados en un JSON
+    @Operation(summary = "Listar departamentos y municipios", description = "Devuelve la estructura completa de departamentos con sus municipios anidados. Útil para construir selectores en cascada.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Estructura de departamentos y municipios",
+                content = @Content(schema = @Schema(implementation = Departamento.class)))
+    })
     @GetMapping("/public/departments-and-municipalities")
     public ResponseEntity<List<Departamento>> listarDepartamentosMunicipios() {
         return ResponseEntity.ok(ubicacionService.listarDepartamentos());
     }
 
-    //Obtener solo departamentos
+    @Operation(summary = "Listar departamentos", description = "Devuelve únicamente los departamentos (código y nombre) sin municipios anidados.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de departamentos",
+                content = @Content(schema = @Schema(implementation = DepartamentoSimpleResponse.class)))
+    })
     @GetMapping("/public/departments")
-    public ResponseEntity<List<DepartamentoSimpleResponse>>listarDepartamentos() {
-       List <Departamento> departamentos= ubicacionService.listarDepartamentos();
+    public ResponseEntity<List<DepartamentoSimpleResponse>> listarDepartamentos() {
+        List<Departamento> departamentos = ubicacionService.listarDepartamentos();
         return ResponseEntity.ok(departamentos.stream()
                 .map(dep -> new DepartamentoSimpleResponse(dep.codigo(), dep.nombre()))
                 .toList());
     }
-    //Obtener municipios relacionados a un departamento
+
+    @Operation(summary = "Listar municipios por departamento", description = "Devuelve todos los municipios pertenecientes al departamento identificado por su código.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de municipios del departamento",
+                content = @Content(schema = @Schema(implementation = Municipio.class))),
+        @ApiResponse(responseCode = "404", description = "Departamento no encontrado", content = @Content)
+    })
     @GetMapping("/public/departments/{code}/municipalities")
-    public ResponseEntity<List<Municipio>> listarMunicipios(@PathVariable String code) {
+    public ResponseEntity<List<Municipio>> listarMunicipios(
+            @Parameter(description = "Código del departamento", example = "05")
+            @PathVariable String code) {
         return ResponseEntity.ok(ubicacionService.municipiosPorDepartamento(code));
     }
-    //Obtener instituciones asociadadas a departamento y municipio
+
+    @Operation(summary = "Listar instituciones por ubicación", description = "Devuelve las instituciones registradas en un departamento y municipio específico, identificados por sus códigos.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de instituciones en la ubicación",
+                content = @Content(schema = @Schema(implementation = InstitucionResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Departamento o municipio no encontrado", content = @Content)
+    })
     @GetMapping("/public/institutions/{departamentoCodigo}/{municipioCodigo}")
-    public ResponseEntity<List<InstitucionResponse>> getInstituciones(
+    public ResponseEntity<List<InstitucionResponse>> getInstitucionesPorUbicacion(
+            @Parameter(description = "Código del departamento", example = "05")
             @PathVariable String departamentoCodigo,
+            @Parameter(description = "Código del municipio", example = "001")
             @PathVariable String municipioCodigo) {
 
         String nombreDepartamento = ubicacionService.nombreDepartamento(departamentoCodigo);
@@ -75,7 +114,12 @@ public class InstitucionController {
                         .toList()
         );
     }
-    //Obtener todas las instituciones registradas
+
+    @Operation(summary = "Listar todas las instituciones", description = "Devuelve todas las instituciones registradas en el sistema.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado completo de instituciones",
+                content = @Content(schema = @Schema(implementation = InstitucionResponse.class)))
+    })
     @GetMapping("/public/institutions-all")
     public ResponseEntity<List<InstitucionResponse>> getInstituciones() {
         return ResponseEntity.ok(listarInstitucionesUseCase.listarInstituciones().stream()

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/MetadataController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/MetadataController.java
@@ -12,6 +12,11 @@ import com.escaes.jobsy.infraestructure.mapper.CategoriaMapper;
 import com.escaes.jobsy.infraestructure.mapper.EstadoMapper;
 import com.escaes.jobsy.infraestructure.mapper.GeneroMapper;
 import com.escaes.jobsy.infraestructure.mapper.PagoMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@Tag(name="Metadata", description = "Metadatos para alimentar otros Enpoints")
+@Tag(name = "Metadata", description = "Endpoints públicos de consulta para poblar formularios y filtros en el frontend")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class MetadataController {
@@ -34,26 +39,44 @@ public class MetadataController {
     private final ListarPagosUseCase listarPagosUseCase;
 
 
+    @Operation(summary = "Listar categorías (metadata)", description = "Devuelve todas las categorías disponibles. Usado para poblar selectores en formularios de creación de trabajos.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de categorías",
+                content = @Content(schema = @Schema(implementation = CatergoriaResponse.class)))
+    })
     @GetMapping("/lookups/category-all")
     public ResponseEntity<List<CatergoriaResponse>> listarCategoriasMetaData(){
         return ResponseEntity.ok(listarCategoriasUseCase.listarCategorias().stream()
                 .map(CategoriaMapper::entityToResponse).toList());
     }
 
-
+    @Operation(summary = "Listar estados (metadata)", description = "Devuelve todos los estados de trabajo disponibles. Usado para filtros y selectores en el frontend.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de estados",
+                content = @Content(schema = @Schema(implementation = EstadoResponse.class)))
+    })
     @GetMapping("/lookups/state-all")
     public ResponseEntity<List<EstadoResponse>> getAllEstadoMetaData(){
         return ResponseEntity.ok(listarEstadosUseCase.listarEstados().stream()
                 .map(EstadoMapper::entityToResponse).toList());
     }
 
-
+    @Operation(summary = "Listar géneros (metadata)", description = "Devuelve todos los géneros disponibles para el perfil de usuario.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de géneros",
+                content = @Content(schema = @Schema(implementation = GeneroResponse.class)))
+    })
     @GetMapping("/lookups/gender-all")
     public ResponseEntity<List<GeneroResponse>> getAllGenerosMetaData(){
         return ResponseEntity.ok(listarGenerosUseCase.listarGeneros()
                 .stream().map(GeneroMapper::entityToResponse).toList());
     }
 
+    @Operation(summary = "Listar tipos de pago (metadata)", description = "Devuelve todos los tipos de pago disponibles (ej. EFECTIVO, TRANSFERENCIA). Usado para el formulario de creación de trabajo.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de tipos de pago",
+                content = @Content(schema = @Schema(implementation = PagoResponse.class)))
+    })
     @GetMapping("/lookups/payment-all")
     public ResponseEntity<List<PagoResponse>> getAllPagosMetaData(){
         return ResponseEntity.ok(listarPagosUseCase.listar()

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/SolicitudesController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/SolicitudesController.java
@@ -6,6 +6,13 @@ import com.escaes.jobsy.application.dto.solicitud.SolicitudUsuarioResponse;
 import com.escaes.jobsy.application.usecase.solicitud.GestionSolicitudesUseCase;
 import com.escaes.jobsy.application.usecase.solicitud.ListarSolicitudesUseCase;
 import com.escaes.jobsy.infraestructure.mapper.SolicitudMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +25,8 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 @RestController
-@Tag(name = "Solicitudes", description = "Operaciones relacionadas con solicitudes a trabajos")
+@Tag(name = "Solicitudes", description = "Gestión de postulaciones a trabajos — todos los endpoints requieren autenticación JWT")
+@SecurityRequirement(name = "bearerAuth")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class SolicitudesController {
@@ -29,32 +37,52 @@ public class SolicitudesController {
 
     private static final Logger LOG = Logger.getLogger(SolicitudesController.class.getName());
 
+    @Operation(summary = "Postularse a un trabajo", description = "Crea una solicitud del usuario autenticado para el trabajo indicado en el body. El correo del solicitante se extrae del token JWT.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Solicitud creada exitosamente",
+                content = @Content(schema = @Schema(implementation = SolicitudResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos o el usuario ya se postuló", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado", content = @Content)
+    })
     @PostMapping("/requests")
     public ResponseEntity<SolicitudResponse> aplicarTrabajo(@RequestBody @Valid SolicitudRequest request,
             Authentication authentication) {
 
-        // El correo lo obtenemos del token
         String trabajadorCorreo = authentication.getName();
 
         return ResponseEntity
                 .ok(SolicitudMapper.toResponse(gestionSolicitudesUseCase.crearSolicitud(request, trabajadorCorreo)));
     }
 
+    @Operation(summary = "Listar postulaciones de un trabajo", description = "Devuelve todas las solicitudes recibidas para un trabajo específico. Solo el creador del trabajo puede consultarlas.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de postulaciones al trabajo",
+                content = @Content(schema = @Schema(implementation = SolicitudUsuarioResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "El usuario no es el creador del trabajo", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado", content = @Content)
+    })
     @GetMapping("/requests/job/{jobId}")
     public ResponseEntity<List<SolicitudUsuarioResponse>> aplicacionesTrabajoId(
+            @Parameter(description = "ID UUID del trabajo", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
             @PathVariable UUID jobId, Authentication authentication) {
         LOG.info("Listando solicitudes para trabajo con Id: " + jobId);
 
-        // El correo lo obtenemos del token; solo el creador del trabajo puede consultarlas
         return ResponseEntity.ok(
                 listarSolicitudesUseCase.listarSolicitudes(jobId, authentication.getName()));
     }
 
+    @Operation(summary = "Mis postulaciones", description = "Devuelve todas las solicitudes enviadas por el usuario autenticado.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de postulaciones del usuario",
+                content = @Content(schema = @Schema(implementation = SolicitudResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @GetMapping("/requests-applied")
     public ResponseEntity<List<SolicitudResponse>> aplicacionesTrabajoCorreoUser(Authentication authentication) {
         LOG.info("Listando aplicaciones para usuario con correo: " + authentication.getName());
 
-        // El correo lo obtenemos del token
         String trabajadorCorreo = authentication.getName();
 
         return ResponseEntity.ok(listarSolicitudesUseCase.listarSolicitudesPorUsuario(trabajadorCorreo));

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/TrabajoController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/TrabajoController.java
@@ -7,6 +7,13 @@ import com.escaes.jobsy.application.usecase.trabajo.GestionTrabajosUseCase;
 import com.escaes.jobsy.application.usecase.trabajo.ListarTrabajosUseCase;
 import com.escaes.jobsy.domain.model.Trabajo;
 import com.escaes.jobsy.infraestructure.mapper.TrabajoMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,7 +26,7 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 @RestController
-@Tag(name = "Trabajos", description = "Operaciones relacionadas con trabajos")
+@Tag(name = "Trabajos", description = "Gestión completa del ciclo de vida de trabajos: publicación, búsqueda, asignación, finalización y abandono")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class TrabajoController {
@@ -30,45 +37,56 @@ public class TrabajoController {
 
     private static final Logger LOG = Logger.getLogger(TrabajoController.class.getName());
 
+    @Operation(summary = "Publicar trabajo", description = "Crea y publica un nuevo trabajo. El solicitante se toma del token JWT del usuario autenticado.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Trabajo creado y publicado exitosamente",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos (campos requeridos faltantes, categoría o estado inexistente)", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @PostMapping("/jobs/create")
     public ResponseEntity<TrabajoResponse> crearTrabajo(
             @RequestBody CrearTrabajoRequest request,
             Authentication authentication) {
-        // El correo lo obtenemos del token
         String solicitanteCorreo = authentication.getName();
-
-        // Ejecutamos el caso de uso
         Trabajo trabajoCreado = gestionTrabajosUseCase.crearTrabajo(request, solicitanteCorreo);
         LOG.info("Trabajo creado correctamente para usuario: " + solicitanteCorreo);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(TrabajoMapper.entityToResponse(trabajoCreado));
     }
 
+    @Operation(summary = "Listar todos los trabajos", description = "Devuelve todos los trabajos publicados en la plataforma. Endpoint público.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de todos los trabajos",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class)))
+    })
     @GetMapping("/public/all-jobs")
     public ResponseEntity<List<TrabajoResponse>> obtenerTrabajos() {
-
-        // Ejecutamos el caso de uso
         List<Trabajo> trabajos = listarTrabajosUseCase.listar();
-
         List<TrabajoResponse> responses = trabajos.stream()
                 .map(TrabajoMapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(responses);
-
     }
 
+    @Operation(summary = "Buscar trabajos con filtros", description = "Búsqueda dinámica de trabajos con múltiples filtros opcionales. Soporta paginación. Endpoint público.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de trabajos que coinciden con los filtros",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class)))
+    })
     @GetMapping("/public/jobs/search")
     public ResponseEntity<List<TrabajoResponse>> buscarTrabajos(
-            @RequestParam(required = false) String titulo,
-            @RequestParam(required = false) String categoria,
-            @RequestParam(required = false) String estado,
-            @RequestParam(required = false) String ubicacion,
-            @RequestParam(required = false) String tipoPago,
-            @RequestParam(required = false) Double pagoMin,
-            @RequestParam(required = false) Double pagoMax,
-            @RequestParam(required = false) String solicitanteCorreo,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "0") int page) {
+            @Parameter(description = "Filtrar por título (búsqueda parcial)", example = "Diseño") @RequestParam(required = false) String titulo,
+            @Parameter(description = "Filtrar por nombre de categoría", example = "Tecnología") @RequestParam(required = false) String categoria,
+            @Parameter(description = "Filtrar por estado del trabajo", example = "DISPONIBLE") @RequestParam(required = false) String estado,
+            @Parameter(description = "Filtrar por nombre de ubicación", example = "Campus Norte") @RequestParam(required = false) String ubicacion,
+            @Parameter(description = "Filtrar por tipo de pago", example = "EFECTIVO") @RequestParam(required = false) String tipoPago,
+            @Parameter(description = "Pago mínimo", example = "10000") @RequestParam(required = false) Double pagoMin,
+            @Parameter(description = "Pago máximo", example = "100000") @RequestParam(required = false) Double pagoMax,
+            @Parameter(description = "Filtrar por correo del solicitante", example = "usuario@email.com") @RequestParam(required = false) String solicitanteCorreo,
+            @Parameter(description = "Cantidad de resultados por página", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "Número de página (base 0)", example = "0") @RequestParam(defaultValue = "0") int page) {
 
         List<TrabajoResponse> responses = listarTrabajosUseCase.buscarTrabajos(
                 titulo, categoria, estado, ubicacion, tipoPago, pagoMin, pagoMax,
@@ -79,28 +97,35 @@ public class TrabajoController {
         return ResponseEntity.ok(responses);
     }
 
+    @Operation(summary = "Mis trabajos publicados", description = "Devuelve los trabajos publicados por el usuario autenticado.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de trabajos publicados por el usuario",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @GetMapping("/jobs/posted-by-me")
     public ResponseEntity<List<TrabajoResponse>> obtenerTrabajosMyJobs(Authentication auth) {
         String solicitanteCorreo = auth.getName();
-
-        // Ejecutamos el caso de uso
         List<Trabajo> trabajos = listarTrabajosUseCase.listarPorUsuarioSolicitante(solicitanteCorreo);
-
         List<TrabajoResponse> responses = trabajos.stream()
                 .map(TrabajoMapper::entityToResponse)
                 .toList();
         LOG.info("Trabajos obtenidos para usuario: " + solicitanteCorreo);
         return ResponseEntity.ok(responses);
-    
     }
 
+    @Operation(summary = "Trabajos en los que participo", description = "Devuelve los trabajos en los que el usuario autenticado está registrado como trabajador.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de trabajos donde el usuario es trabajador",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @GetMapping("/jobs/worked-by-me")
     public ResponseEntity<List<TrabajoResponse>> obtenerTrabajosWorkedByMe(Authentication auth) {
         String trabajadorCorreo = auth.getName();
-
-        // Ejecutamos el caso de uso
         List<Trabajo> trabajos = listarTrabajosUseCase.listarPorUsuarioTrabajador(trabajadorCorreo);
-
         List<TrabajoResponse> responses = trabajos.stream()
                 .map(TrabajoMapper::entityToResponse)
                 .toList();
@@ -108,57 +133,99 @@ public class TrabajoController {
         return ResponseEntity.ok(responses);
     }
 
+    @Operation(summary = "Asignar trabajador a un trabajo", description = "Asigna un trabajador (identificado por su solicitud) al trabajo indicado. Solo el creador del trabajo puede realizar esta acción.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Trabajador asignado exitosamente",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "El trabajo ya tiene trabajador asignado", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo o solicitud no encontrada", content = @Content)
+    })
     @PatchMapping("/jobs/apply-job/{jobId}")
-    public ResponseEntity<TrabajoResponse> aplicarTrabajo(@PathVariable UUID jobId,UUID solicitudId,Authentication auth){
-        String trabajadorCorreo= auth.getName();
-
-        //Ejecutamos el caso de uso
-        Trabajo appliedJob=gestionTrabajosUseCase.asignarTrabajo(jobId, solicitudId);
+    public ResponseEntity<TrabajoResponse> aplicarTrabajo(
+            @Parameter(description = "ID UUID del trabajo", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+            @PathVariable UUID jobId, UUID solicitudId, Authentication auth){
+        String trabajadorCorreo = auth.getName();
+        Trabajo appliedJob = gestionTrabajosUseCase.asignarTrabajo(jobId, solicitudId);
         LOG.info("Trabajo aplicado correo: " + trabajadorCorreo);
         return ResponseEntity.ok(TrabajoMapper.entityToResponse(appliedJob));
     }
 
+    @Operation(summary = "Retirar asignación de un trabajo", description = "Elimina la asignación del trabajador autenticado en el trabajo indicado.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Asignación eliminada exitosamente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado o el usuario no está asignado", content = @Content)
+    })
     @PatchMapping("/jobs/unassigned-job/{jobId}")
-    public ResponseEntity<Void>eliminarTrabajoAsignado(@PathVariable UUID jobId,Authentication auth){
-        String trabajadorCorreo= auth.getName();
+    public ResponseEntity<Void> eliminarTrabajoAsignado(
+            @Parameter(description = "ID UUID del trabajo", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+            @PathVariable UUID jobId, Authentication auth){
+        String trabajadorCorreo = auth.getName();
         gestionTrabajosUseCase.eliminarAplicacionATrabajoCorreoTrabajador(jobId, trabajadorCorreo);
         LOG.info("Trabajo quita aplicación correo: " + trabajadorCorreo);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Eliminar trabajo publicado", description = "Elimina permanentemente un trabajo publicado por el usuario autenticado. Solo el creador puede eliminarlo.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Trabajo eliminado exitosamente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "El usuario no es el creador del trabajo", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado", content = @Content)
+    })
     @DeleteMapping("/jobs/published/delete/{jobId}")
-    public ResponseEntity<Void> eliminarTrabajoPublicado(@PathVariable UUID jobId, Authentication auth) {
+    public ResponseEntity<Void> eliminarTrabajoPublicado(
+            @Parameter(description = "ID UUID del trabajo a eliminar", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+            @PathVariable UUID jobId, Authentication auth) {
         String solicitanteCorreo = auth.getName();
-
-        //Ejecutamos el caso de uso
         gestionTrabajosUseCase.eliminarTrabajoPorIdYUsuarioCorreoSolicitante(jobId, solicitanteCorreo);
         LOG.info("Trabajo eliminado id: " + jobId + " solicitante correo: " + solicitanteCorreo);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Finalizar trabajo", description = "Marca el trabajo como finalizado. Solo el creador puede finalizarlo. Puede incluir valoración del trabajador.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Trabajo finalizado exitosamente",
+                content = @Content(schema = @Schema(implementation = TrabajoResponse.class))),
+        @ApiResponse(responseCode = "400", description = "El trabajo no puede finalizarse en su estado actual", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "El usuario no es el creador del trabajo", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado", content = @Content)
+    })
     @PatchMapping("/jobs/finalize/{jobId}")
     public ResponseEntity<TrabajoResponse> finalizarTrabajo(
+            @Parameter(description = "ID UUID del trabajo a finalizar", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
             @PathVariable UUID jobId,
             @RequestBody FinalizarTrabajoRequest request,
             Authentication auth) {
         String solicitanteCorreo = auth.getName();
-
         Trabajo trabajoFinalizado = gestionTrabajosUseCase.finalizarTrabajo(jobId, request, solicitanteCorreo);
         LOG.info("Trabajo finalizado id: " + jobId + ", solicitante: " + solicitanteCorreo);
         return ResponseEntity.ok(TrabajoMapper.entityToResponse(trabajoFinalizado));
     }
 
+    @Operation(summary = "Abandonar trabajo", description = "El trabajador autenticado abandona el trabajo al que estaba asignado, liberándolo para que otro pueda tomarlo.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Trabajo abandonado exitosamente", content = @Content),
+        @ApiResponse(responseCode = "400", description = "El trabajo no puede abandonarse en su estado actual", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Trabajo no encontrado o el usuario no es el trabajador asignado", content = @Content)
+    })
     @PatchMapping("/jobs/abandon/{jobId}")
-    public ResponseEntity<Void> abandonarTrabajo(@PathVariable UUID jobId, Authentication auth) {
+    public ResponseEntity<Void> abandonarTrabajo(
+            @Parameter(description = "ID UUID del trabajo a abandonar", example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+            @PathVariable UUID jobId, Authentication auth) {
         String trabajadorCorreo = auth.getName();
-
-        //Ejecutamos el caso de uso
         gestionTrabajosUseCase.abandonarTrabajoPorIdYUsuarioCorreoTrabajador(jobId, trabajadorCorreo);
         LOG.info("Trabajo abandonado. JobId: " + jobId + ", trabajador: " + trabajadorCorreo);
         return ResponseEntity.noContent().build();
     }
-
-
 
 }
 

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UbicacionController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UbicacionController.java
@@ -5,6 +5,13 @@ import com.escaes.jobsy.application.dto.ubicacion.UbicacionResponse;
 import com.escaes.jobsy.application.usecase.ubicacion.GestionUbicacionUseCase;
 import com.escaes.jobsy.application.usecase.ubicacion.ListarUbicacionUseCase;
 import com.escaes.jobsy.infraestructure.mapper.UbicacionMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,7 +22,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 @RestController
-@Tag(name = "Ubicaciones", description = "Operaciones relacionadas con ubicaciones enfocadas en trabajos")
+@Tag(name = "Ubicaciones", description = "Gestión de ubicaciones de trabajos — los endpoints de escritura/eliminación requieren autenticación")
 @RequestMapping("/v1")
 @RequiredArgsConstructor
 public class UbicacionController {
@@ -27,8 +34,16 @@ public class UbicacionController {
     private static final Logger LOG = Logger.getLogger(UbicacionController.class.getName());
 
 
+    @Operation(summary = "Crear ubicación", description = "Registra una nueva ubicación para ser asociada a trabajos.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Ubicación creada exitosamente",
+                content = @Content(schema = @Schema(implementation = UbicacionResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos o ubicación ya existente", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @PostMapping("/ubication")
-    public ResponseEntity<UbicacionResponse>createUbicacion(@RequestBody UbicacionRequest ubicacionRequest){
+    public ResponseEntity<UbicacionResponse> createUbicacion(@RequestBody UbicacionRequest ubicacionRequest){
         LOG.info("Solicitud de creación de ubicación con nombre: "+ ubicacionRequest.nombre());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(UbicacionMapper
@@ -36,8 +51,15 @@ public class UbicacionController {
                                 .crear(ubicacionRequest)));
     }
 
+    @Operation(summary = "Listar todas las ubicaciones", description = "Devuelve todas las ubicaciones registradas.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de ubicaciones",
+                content = @Content(schema = @Schema(implementation = UbicacionResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @GetMapping("/ubication")
-    public ResponseEntity<List<UbicacionResponse>>listarUbicacion() {
+    public ResponseEntity<List<UbicacionResponse>> listarUbicacion() {
         LOG.info("Solicitud obtener todas las ubicaciones");
         List<UbicacionResponse> responses = listarUbicacionUseCase
                 .buscarTodos()
@@ -46,19 +68,33 @@ public class UbicacionController {
         return ResponseEntity.ok((responses));
     }
 
+    @Operation(summary = "Listar ubicaciones (metadata)", description = "Endpoint público para poblar selectores de ubicación en formularios del frontend.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de ubicaciones",
+                content = @Content(schema = @Schema(implementation = UbicacionResponse.class)))
+    })
     @GetMapping("/lookups/ubication")
-    public ResponseEntity<List<UbicacionResponse>>listarUbicacionMetaData(){
+    public ResponseEntity<List<UbicacionResponse>> listarUbicacionMetaData(){
         LOG.info("Solicitud obtener todas las ubicaciones");
-        List<UbicacionResponse>responses = listarUbicacionUseCase
+        List<UbicacionResponse> responses = listarUbicacionUseCase
                 .buscarTodos()
                 .stream()
                 .map(UbicacionMapper::domainToResponse).toList();
         return ResponseEntity.ok((responses));
     }
 
-
+    @Operation(summary = "Buscar ubicación por nombre", description = "Retorna la ubicación cuyo nombre coincida exactamente.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Ubicación encontrada",
+                content = @Content(schema = @Schema(implementation = UbicacionResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Ubicación no encontrada", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @GetMapping("/ubication/{name}")
-    public ResponseEntity<UbicacionResponse>obtenerUbicacion(@PathVariable String name){
+    public ResponseEntity<UbicacionResponse> obtenerUbicacion(
+            @Parameter(description = "Nombre exacto de la ubicación", example = "Campus Norte")
+            @PathVariable String name){
         LOG.info("Solicitud obtener ubicación con nombre: "+ name);
         UbicacionRequest ubicacionRequest = new UbicacionRequest(name);
         return ResponseEntity.ok(UbicacionMapper
@@ -66,9 +102,17 @@ public class UbicacionController {
                         .buscarPorNombre(ubicacionRequest)));
     }
 
-
+    @Operation(summary = "Eliminar ubicación por nombre", description = "Elimina permanentemente la ubicación con el nombre indicado.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "Ubicación eliminada exitosamente", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Ubicación no encontrada", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content)
+    })
     @DeleteMapping("/ubication/{name}")
-    public ResponseEntity<UbicacionResponse> deleteUbicacion(@PathVariable String name){
+    public ResponseEntity<UbicacionResponse> deleteUbicacion(
+            @Parameter(description = "Nombre exacto de la ubicación a eliminar", example = "Campus Norte")
+            @PathVariable String name){
         LOG.info("Solicitud eliminar ubicación con nombre: "+ name);
         UbicacionRequest ubicacionRequest = new UbicacionRequest(name);
         gestionUbicacionUseCase.eliminarPorNombre(ubicacionRequest);

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UsuarioController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UsuarioController.java
@@ -11,6 +11,13 @@ import com.escaes.jobsy.domain.model.Genero;
 import com.escaes.jobsy.domain.model.Rol;
 import com.escaes.jobsy.domain.model.Usuario;
 import com.escaes.jobsy.infraestructure.mapper.UsuarioMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,7 +30,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/v1")
-@Tag(name = "Usuarios", description = "Operaciones relacionadas con usuarios")
+@Tag(name = "Usuarios", description = "Gestión de usuarios — registro público y administración con rol ADMIN")
 @RequiredArgsConstructor
 public class UsuarioController {
 
@@ -36,23 +43,39 @@ public class UsuarioController {
     private final GestionRolesUseCase gestionRolesUseCase;
 
 
+    @Operation(summary = "Registrar usuario", description = "Crea una nueva cuenta de usuario. Endpoint público — no requiere autenticación. El rol por defecto es USER si no se especifica.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "201", description = "Usuario creado exitosamente",
+                content = @Content(schema = @Schema(implementation = UsuarioResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Datos inválidos (correo duplicado, campos faltantes, etc.)", content = @Content)
+    })
     @PostMapping("/public/users/create")
-    public ResponseEntity<UsuarioResponse>crearUsuario(@RequestBody UsuarioRequest request) {
+    public ResponseEntity<UsuarioResponse> crearUsuario(@RequestBody UsuarioRequest request) {
 
-        Genero genero= gestionGenerosUseCase.obtenerGeneroPorNombre(request.genero());
+        Genero genero = gestionGenerosUseCase.obtenerGeneroPorNombre(request.genero());
 
         Rol rol = gestionRolesUseCase.obtenerRolPorNombre(
                 request.rol() != null ? request.rol() : "USER"
         );
 
-        gestionUsuariosUseCase.crearUsuario(request,genero,rol);
-
+        gestionUsuariosUseCase.crearUsuario(request, genero, rol);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(UsuarioMapper.requestToResponse(request));
     }
 
+    @Operation(summary = "Obtener usuario por documento", description = "Devuelve los datos de un usuario a partir de su número de documento. Requiere rol ADMIN.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Usuario encontrado",
+                content = @Content(schema = @Schema(implementation = UsuarioResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Usuario no encontrado", content = @Content),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/users/{documento}")
-    public ResponseEntity<UsuarioResponse> obtenerPorDocumento(@PathVariable Integer documento) {
+    public ResponseEntity<UsuarioResponse> obtenerPorDocumento(
+            @Parameter(description = "Número de documento de identidad del usuario", example = "1234567890")
+            @PathVariable Integer documento) {
 
         Usuario usuario = gestionUsuariosUseCase.obtenerUsuarioPorId(documento);
         if (usuario == null) {
@@ -61,17 +84,25 @@ public class UsuarioController {
         return ResponseEntity.ok(UsuarioMapper.entityToResponse(usuario));
     }
 
+    @Operation(summary = "Buscar usuarios con filtros", description = "Permite buscar usuarios aplicando múltiples filtros opcionales. Soporta paginación. Requiere rol ADMIN.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Listado de usuarios que coinciden con los filtros",
+                content = @Content(schema = @Schema(implementation = UsuarioResponse.class))),
+        @ApiResponse(responseCode = "401", description = "No autenticado", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Sin permisos de ADMIN", content = @Content)
+    })
     @GetMapping("/admin/users/search")
     public ResponseEntity<List<UsuarioResponse>> buscarUsuarios(
-            @RequestParam(required = false) Integer documento,
-            @RequestParam(required = false) String correo,
-            @RequestParam(required = false) String genero,
-            @RequestParam(required = false) String rol,
-            @RequestParam(required = false) Boolean bloqueado,
-            @RequestParam(required = false) Integer valoracionConteo,
-            @RequestParam(required = false) Double valoracionPromedio,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "0") int page) {
+            @Parameter(description = "Número de documento", example = "1234567890") @RequestParam(required = false) Integer documento,
+            @Parameter(description = "Correo electrónico del usuario", example = "usuario@email.com") @RequestParam(required = false) String correo,
+            @Parameter(description = "Género del usuario (ej. MASCULINO)", example = "MASCULINO") @RequestParam(required = false) String genero,
+            @Parameter(description = "Rol del usuario (USER o ADMIN)", example = "USER") @RequestParam(required = false) String rol,
+            @Parameter(description = "Filtrar por estado bloqueado", example = "false") @RequestParam(required = false) Boolean bloqueado,
+            @Parameter(description = "Mínimo de valoraciones recibidas", example = "5") @RequestParam(required = false) Integer valoracionConteo,
+            @Parameter(description = "Promedio mínimo de valoración (0.0 - 5.0)", example = "4.0") @RequestParam(required = false) Double valoracionPromedio,
+            @Parameter(description = "Cantidad de resultados por página", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "Número de página (base 0)", example = "0") @RequestParam(defaultValue = "0") int page) {
 
         List<UsuarioResponse> usuarios = listarUsuariosUseCase.buscarUsuarios(
                 documento, correo, genero, rol, bloqueado, valoracionConteo, valoracionPromedio, size, page)


### PR DESCRIPTION
- Added detailed Swagger annotations to the GeneroController for creating new genres, including security requirements and response descriptions.
- Updated InstitucionController with Swagger annotations for creating institutions, listing departments and municipalities, and retrieving institutions by location, enhancing clarity and usability.
- Improved MetadataController with Swagger documentation for listing categories, states, genders, and payment types, ensuring comprehensive metadata access.
- Enhanced SolicitudesController with Swagger annotations for job applications and listing user applications, specifying authentication requirements and response details.
- Updated TrabajoController with extensive Swagger documentation for job management operations, including creation, searching, and assignment, emphasizing security and response clarity.
- Improved UbicacionController with Swagger annotations for location management, including creation, listing, and deletion of locations, ensuring proper documentation of endpoints.
- Enhanced UsuarioController with Swagger documentation for user registration, retrieval by document, and searching users with filters, specifying authentication and authorization requirements.