### PR TITLE
feat: Calificación: Exponer valoracionPromedio en perfil de usuario y postulaciones recibidas

### DIFF
--- a/src/main/java/com/escaes/jobsy/application/dto/solicitud/SolicitudUsuarioResponse.java
+++ b/src/main/java/com/escaes/jobsy/application/dto/solicitud/SolicitudUsuarioResponse.java
@@ -10,5 +10,6 @@ public record SolicitudUsuarioResponse(UUID solicitudId,
                                        String correoUsuario,
                                        String telefonoUsuario,
                                        EstadoSolicitud estado,
-                                       LocalDateTime fechaSolicitud) {
+                                       LocalDateTime fechaSolicitud,
+                                       Double valoracionPromedio) {
 }

--- a/src/main/java/com/escaes/jobsy/infraestructure/mapper/SolicitudMapper.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/mapper/SolicitudMapper.java
@@ -57,7 +57,8 @@ public class SolicitudMapper {
                 solicitud.trabajador().correo(),
                 solicitud.trabajador().telefono(),
                 solicitud.estado(),
-                solicitud.fechaCreacion()
+                solicitud.fechaCreacion(),
+                solicitud.trabajador().valoracionPromedio()
         );
     }
 }

--- a/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UsuarioController.java
+++ b/src/main/java/com/escaes/jobsy/infraestructure/rest/controller/UsuarioController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
@@ -79,5 +80,14 @@ public class UsuarioController {
                 .map(UsuarioMapper::entityToResponse)
                 .toList();
         return ResponseEntity.ok(usuarios);
+    }
+
+    @GetMapping("/usuarios/perfil")
+    public ResponseEntity<UsuarioResponse> obtenerPerfil(Authentication authentication) {
+        String correo = authentication.getName();
+        Usuario usuario = listarUsuariosUseCase
+                .buscarUsuarios(null, correo, null, null, null, null, null, 1, 0)
+                .stream().findFirst().orElseThrow();
+        return ResponseEntity.ok(UsuarioMapper.entityToResponse(usuario));
     }
 }


### PR DESCRIPTION
- UsuarioController: agrega endpoint GET /v1/usuarios/perfil que lee el usuario del JWT y retorna su UsuarioResponse incluyendo valoracionPromedio
- SolicitudUsuarioResponse: agrega campo valoracionPromedio al record para exponer la calificación del candidato en el listado de postulaciones
- SolicitudMapper: popula valoracionPromedio desde el trabajador en el método toUserResponse